### PR TITLE
Stop the email notification spam

### DIFF
--- a/LSSD.Registration.NotificationHandlers.EmailNotificationHandler/EmailNotificationHandler.cs
+++ b/LSSD.Registration.NotificationHandlers.EmailNotificationHandler/EmailNotificationHandler.cs
@@ -113,13 +113,9 @@ namespace LSSD.Registration.NotificationHandlers.EmailNotificationHandler
                             }
                         }
                     }
-                    
-                    // Remove successful notifications from the backlog
-                    // But keep unsuccessful ones.
-                    foreach(INotifiable form in successfulNotifications) {
-                        _backlog.Remove(form);
-                    }
 
+                    // Empty the queue. Some may have failed, but they won't be marked as notified in the DB, so the next run will catch them.
+                    _backlog.Clear();
                 }
             }
 

--- a/LSSD.Registration.NotificationHandlers.EmailNotificationHandler/EmailNotificationHandler.cs
+++ b/LSSD.Registration.NotificationHandlers.EmailNotificationHandler/EmailNotificationHandler.cs
@@ -53,7 +53,6 @@ namespace LSSD.Registration.NotificationHandlers.EmailNotificationHandler
                     Credentials = new NetworkCredential(_smtpConnectionDetails.Username, _smtpConnectionDetails.Password)
                 })
                 {
-                    List<INotifiable> successfulNotifications = new List<INotifiable>();
                     foreach(INotifiable form in _backlog)
                     {
                         // Determine recipients of the message
@@ -104,7 +103,6 @@ namespace LSSD.Registration.NotificationHandlers.EmailNotificationHandler
                                     smtpClient.Send(msg);
                                 }
 
-                                successfulNotifications.Add(form);
                                 form.NotificationSent = true;
                             } 
                             catch(Exception ex) {
@@ -115,6 +113,7 @@ namespace LSSD.Registration.NotificationHandlers.EmailNotificationHandler
                     }
 
                     // Empty the queue. Some may have failed, but they won't be marked as notified in the DB, so the next run will catch them.
+                    // This prevents an SMTP outage from enqueuing the same email hundreds of times.
                     _backlog.Clear();
                 }
             }


### PR DESCRIPTION
Prevents the email notification handler from saving failed emails which later get re-queued, duplicating the notification.