### PR TITLE
Minor cosmetic changes

### DIFF
--- a/LSSD.Registration.CustomerFrontEnd/Components/Parts/FooterComponent.razor
+++ b/LSSD.Registration.CustomerFrontEnd/Components/Parts/FooterComponent.razor
@@ -8,7 +8,7 @@
         </div>
 
         <div class="text-center col">
-            <a href="https://www.lskysd.ca">Living Sky School Division No. 202</a>
+            <a href="https://www.livingskysd.ca">Living Sky School Division No. 202</a>
         </div>
 
         <div class="text-right col">

--- a/LSSD.Registration.CustomerFrontEnd/Pages/Index.razor
+++ b/LSSD.Registration.CustomerFrontEnd/Pages/Index.razor
@@ -6,27 +6,7 @@
 }
 <HeaderComponent FullHeight="true" />
 <div class="container">
-    <br /><br />
-    <h3 style="border-bottom: 1px solid #C0C0C0;">Pre-Kindergarten Online Application</h3>
-    <div class="row">
-        <div class="col-sm-4">
-            <div class="card mx-auto" style="width: 18rem;">
-                <img class="card-img-top" src="images/cap-prek.png" alt="Card image cap">
-                <div class="card-body">
-                    <a href="PreK" class="btn btn-primary btn-block">Apply for Pre-K</a>
-                </div>
-            </div>
-        </div>
-        <div class="col-sm-8">
-            <p>
-                Pre-K programs support the overall development of young children and lay the foundation for school success and lifelong learning.
-            </p>
-            <p>
-                Pre-K is intended to be a prevention and early intervention program. Therefore, a priority is given to children who are at risk or most vulnerable. Applications are reviewed by a selection committee who will inform parents of decisions made about entry into the program.
-            </p>
-        </div>
-    </div>
-    <br /><br />
+    <br /><br />    
     <h3 style="border-bottom: 1px solid #C0C0C0;">K-12 Online Registration</h3>
     <div class="row">
         <div class="col-sm-4">
@@ -43,6 +23,27 @@
             </p>
             <p>
                 Start here to register for any grade at any Living Sky School Division school. Please call 306-937-7702 if you have any questions.
+            </p>
+        </div>
+    </div>
+
+    <br /><br />
+    <h3 style="border-bottom: 1px solid #C0C0C0;">Pre-Kindergarten Online Application (Select schools only)</h3>
+    <div class="row">
+        <div class="col-sm-4">
+            <div class="card mx-auto" style="width: 18rem;">
+                <img class="card-img-top" src="images/cap-prek.png" alt="Card image cap">
+                <div class="card-body">
+                    <a href="PreK" class="btn btn-primary btn-block">Apply for Pre-K</a>
+                </div>
+            </div>
+        </div>
+        <div class="col-sm-8">
+            <p>
+                Pre-K programs support the overall development of young children and lay the foundation for school success and lifelong learning.
+            </p>
+            <p>
+                Pre-K is intended to be a prevention and early intervention program. Therefore, a priority is given to children who are at risk or most vulnerable. Applications are reviewed by a selection committee who will inform parents of decisions made about entry into the program.
             </p>
         </div>
     </div>


### PR DESCRIPTION
- Re-order main page buttons so that PreK is below K-12. Parents stopped reading after the first line, and assumed all schools had PreK, and assumed it was a programming error that they couldn't select schools that don't offer the program.
- Added "Select Schools" to PreK to (hopefully) drive the point home that all schools don't necessarily offer Pre-K
- Updated the URL for Living Sky's main website