### PR TITLE
Change default API URL to use the main public one.

### DIFF
--- a/LSSD.Registration.CustomerFrontEnd/Properties/launchSettings.json
+++ b/LSSD.Registration.CustomerFrontEnd/Properties/launchSettings.json
@@ -4,7 +4,8 @@
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "Settings__APIURI" : "https://registration-api.lskysd.ca"
       },
       "applicationUrl": "https://localhost:5001;http://localhost:5000"
     },

--- a/LSSD.Registration.CustomerFrontEnd/Startup.cs
+++ b/LSSD.Registration.CustomerFrontEnd/Startup.cs
@@ -34,7 +34,7 @@ namespace LSSD.Registration.CustomerFrontEnd
             IConfigurationSection settingsSection = Configuration.GetSection("Settings");
 
             // Default to what's in Properties/launchSettings.json for the API project.
-            string apiURI = settingsSection["APIURI"] ?? "https://localhost:4001";
+            string apiURI = settingsSection["APIURI"] ?? "https://registration-api.lskysd.ca";
 
             Console.WriteLine("API URL is: " + apiURI);
 


### PR DESCRIPTION
It can be easily overridden using launchSettings.json or environment variables