### PR TITLE
Add contacts for PreK forms

### DIFF
--- a/LSSD.Registration.CustomerFrontEnd/Components/FormSections/PreKFinishSection.razor
+++ b/LSSD.Registration.CustomerFrontEnd/Components/FormSections/PreKFinishSection.razor
@@ -36,6 +36,7 @@
         form.SchoolPreferences = await BrowserStorage.Get<SchoolPreferenceList>(StorageKeys.MultiSchool);
         form.Siblings = await BrowserStorage.Get<SiblingInfo>(StorageKeys.Siblings);
         form.PreKInfo = await BrowserStorage.Get<PreKInfo>(StorageKeys.PreKInfo);
+        form.Contacts =  await BrowserStorage.Get<ContactsInfo>(StorageKeys.Contacts);
 
         if (form.Student != null)
         {

--- a/LSSD.Registration.CustomerFrontEnd/Pages/PreK.razor
+++ b/LSSD.Registration.CustomerFrontEnd/Pages/PreK.razor
@@ -16,6 +16,7 @@
         "RequestorSection",
         "PreKSchoolChooser",
         "PreKStudentDemographicSection",
+        "ContactsSection",
         "SiblingsSection",
         "PreKInfoSection",
         "PreKFinishSection"

--- a/LSSD.Registration.FormGenerators/FormGenerators/PreKApplicationFormGenerator.cs
+++ b/LSSD.Registration.FormGenerators/FormGenerators/PreKApplicationFormGenerator.cs
@@ -42,10 +42,11 @@ namespace LSSD.Registration.FormGenerators.FormGenerators {
             pageParts.AddRange(PageTitleSection.GetSection(Form, TimeZone)); 
             pageParts.AddRange(SchoolPreferencesSection.GetSection(Form.Form.SchoolPreferences));
             pageParts.AddRange(StudentInfoSection.GetSection(Form.Form.Student, TimeZone, true));
-            pageParts.AddRange(SubmittedBySection.GetSection(Form.Form.SubmittedBy));    
+            pageParts.AddRange(SubmittedBySection.GetSection(Form.Form.SubmittedBy)); 
             pageParts.AddRange(SiblingSection.GetSection(Form.Form.Siblings));
             pageParts.AddRange(PreKInfoSection.GetSection(Form.Form.PreKInfo)); 
-            pageParts.AddRange(FormEndSection.GetSection(Form, TimeZone)); 
+            pageParts.AddRange(ContactsSection.GetSection(Form.Form.Contacts));  
+            pageParts.AddRange(FormEndSection.GetSection(Form, TimeZone));    
             return new Document(new Body(pageParts));
         }
     }

--- a/LSSD.Registration.Model/Forms/Examples.cs
+++ b/LSSD.Registration.Model/Forms/Examples.cs
@@ -76,6 +76,119 @@ namespace LSSD.Registration.Forms
                     }
                 } 
             },
+            Contacts = new ContactsInfo()
+            {
+                Contacts = new List<Contact>()
+                {
+                    new Contact()
+                    {
+                        FirstName = "Parent's First Name",
+                        LastName = "Parent's Last Name",
+                        RelationshipToStudent = "Parent",
+                        ContactPriority = 1,
+                        LivesWithStudent = true,
+                        SamePrimaryAddressAsStudent = true,
+                        SameMailingAddressAsStudent = true,
+                        ShouldRecieveMailAboutStudent = true,
+                        HomePhone = "1234567890",
+                        WorkPhone = "0987654321",
+                        CellPhone = "3216540987",
+                        AlternateContactInfo = "Facebook: MyFacebookName",
+                        Employer = "Spacely Space Sprockets Inc",
+                        EmailAddress = "email@domain.com",
+                        PrimaryAddress = new Address()
+                        {
+                            Line1 = "123 Fake Street",
+                            Line2 = "Apartment 72",
+                            City = "Cake Town",
+                            Province = "SK",
+                            Country = "Canada",
+                            PostalCode = "H0H 0H0"
+                        },
+                        MailingAddress = new Address()
+                        {
+                            Line1 = "PO Box 123",
+                            Line2 = "",
+                            City = "Cake Town",
+                            Province = "SK",
+                            PostalCode = "H0H 0H0",
+                            Country = "Canada"
+                        }
+                    },
+                    new Contact()
+                    {
+                        FirstName = "Parent 2's First Name",
+                        LastName = "Parent 2's Last Name",
+                        RelationshipToStudent = "Parent",
+                        ContactPriority = 2,
+                        LivesWithStudent = true,
+                        SamePrimaryAddressAsStudent = true,
+                        SameMailingAddressAsStudent = true,
+                        ShouldRecieveMailAboutStudent = true,
+                        HomePhone = "1234567890",
+                        WorkPhone = "0987654321",
+                        CellPhone = "3216540987",
+                        AlternateContactInfo = "Facebook: MyFacebookName",
+                        Employer = "Spacely Space Sprockets Inc",
+                        EmailAddress = "email@domain.com",
+                        Note = "Not reachable during work day",
+                        PrimaryAddress = new Address()
+                        {
+                            Line1 = "123 Fake Street",
+                            Line2 = "Apartment 72",
+                            City = "Cake Town",
+                            Province = "SK",
+                            Country = "Canada",
+                            PostalCode = "H0H 0H0"
+                        },
+                        MailingAddress = new Address()
+                        {
+                            Line1 = "PO Box 123",
+                            Line2 = "",
+                            City = "Cake Town",
+                            Province = "SK",
+                            PostalCode = "H0H 0H0",
+                            Country = "Canada"
+                        }
+                    },
+                    new Contact()
+                    {
+                        FirstName = "Emergency Contact First Name",
+                        LastName = "Emergency Contact Last Name",
+                        RelationshipToStudent = "Emergency Contact",
+                        ContactPriority = 3,
+                        LivesWithStudent = false,
+                        SamePrimaryAddressAsStudent = false,
+                        SameMailingAddressAsStudent = false,
+                        ShouldRecieveMailAboutStudent = false,
+                        HomePhone = string.Empty,
+                        WorkPhone = "0987654321",
+                        CellPhone = "3216540987",
+                        AlternateContactInfo = string.Empty,
+                        Employer = "Cogswell's Cogs",
+                        EmailAddress = "email@domain.com",
+                        Note = "Has no home phone",
+                        PrimaryAddress = new Address()
+                        {
+                            Line1 = "321 Fake Street",
+                            Line2 = string.Empty,
+                            City = "Cake Town",
+                            Province = "SK",
+                            Country = "Canada",
+                            PostalCode = "H0H 0H0"
+                        },
+                        MailingAddress = new Address()
+                        {
+                            Line1 = "PO Box 123",
+                            Line2 = "",
+                            City = "Cake Town",
+                            Province = "SK",
+                            PostalCode = "H0H 0H0",
+                            Country = "Canada"
+                        }
+                    }
+                }
+            },
             PreKInfo = new PreKInfo() {
                 SocialEmotionalOrBehaviourIssues = string.Empty,
                 ReferredByOtherAgency = string.Empty,

--- a/LSSD.Registration.Model/Forms/PreKRegistrationFormSubmission.cs
+++ b/LSSD.Registration.Model/Forms/PreKRegistrationFormSubmission.cs
@@ -15,5 +15,7 @@ namespace LSSD.Registration.Model.Forms
         public SiblingInfo Siblings { get; set; }
         [Required]
         public PreKInfo PreKInfo { get; set; }
+        [Required]
+        public ContactsInfo Contacts { get; set; }
     }
 }


### PR DESCRIPTION
Contacts were previously left out of the PreK form, because they weren't on the paper form.
This adds the  contacts section from the General/K-12 form to the PreK form as well.