### PR TITLE
Use localhost for testing instead of a distinct test API server

### DIFF
--- a/LSSD.Registration.CustomerFrontEnd/Properties/launchSettings.json
+++ b/LSSD.Registration.CustomerFrontEnd/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "Settings__APIURI" : "https://registration-test-api.lskysd.ca"
+        "Settings__APIURI" : "https://localhost:4001"
       },
       "applicationUrl": "https://localhost:5001;http://localhost:5000"
     },


### PR DESCRIPTION
Updating the API server makes this more of a headache - maybe some day, but I have it working pretty well locally now.